### PR TITLE
feat: create searchspell command with documentation

### DIFF
--- a/rule_documents/text_documents/spellbook.json
+++ b/rule_documents/text_documents/spellbook.json
@@ -501,11 +501,11 @@
       {
         "name": "Redeem",
         "tier": "9",
-        "cost": "24 hours",
+        "cost": "A diamond worth at least 10,000 gp, which this spell consumes.",
         "type": "AoE",
         "range": "1 mile",
+        "duration": "24 hours",
         "effect": "Revive any number of deceased creatures you choose—within 1 mile—that have died in the past year, provided they have not died of old age or been revived with this spell before.",
-        "cost": "A diamond worth at least 10,000 gp, which this spell consumes.",
         "description": "The power to undo death's hold is a heavy burden."
       }
     ],

--- a/src/bot.js
+++ b/src/bot.js
@@ -41,6 +41,15 @@ function startBot() {
     console.log(`Parsed command: '${command}', args: ${args}`);
 
     switch (command) {
+      case COMMANDS.SEARCH_SPELL: {
+        if (!args[0]) {
+          message.reply(USAGE.SEARCH_SPELL);
+          return;
+        }
+        const searchSpell = require("./commands/searchSpell");
+        await searchSpell.execute(message, args);
+        break;
+      }
       case COMMANDS.ADD: {
         if (!args[0]) {
           message.reply(USAGE.ADD);
@@ -134,8 +143,10 @@ function startBot() {
           if (result.modifier !== 0)
             reply += ` ${result.modifier > 0 ? "+" : "-"} ${Math.abs(result.modifier)}`;
           reply += `\nTotal: ${result.total}`;
-          if (result.isCritSuccess) reply += `\n${require('./constants/dice').CRIT_SUCCESS_MSG}`;
-          if (result.isCritFailure) reply += `\n${require('./constants/dice').CRIT_FAILURE_MSG}`;
+          if (result.isCritSuccess)
+            reply += `\n${require("./constants/dice").CRIT_SUCCESS_MSG}`;
+          if (result.isCritFailure)
+            reply += `\n${require("./constants/dice").CRIT_FAILURE_MSG}`;
           message.reply(reply);
         } catch (err) {
           if (err.name && err.message)
@@ -307,10 +318,13 @@ function startBot() {
         try {
           const newHP = damage(characterName, amount);
           if (newHP == -1) {
-            message.reply(`'${characterName}' is already in dying condition (0 HP), please use !wound instead.`);
-          }
-          else {
-            message.reply(`Damaged '${characterName}' by ${amount}. New HP: ${newHP}`);
+            message.reply(
+              `'${characterName}' is already in dying condition (0 HP), please use !wound instead.`,
+            );
+          } else {
+            message.reply(
+              `Damaged '${characterName}' by ${amount}. New HP: ${newHP}`,
+            );
           }
         } catch (err) {
           message.reply(`Error applying damage: ${err.message}`);
@@ -331,12 +345,14 @@ function startBot() {
         const { heal } = require("./commands/heal");
         try {
           const newHP = heal(characterName, amount);
-          message.reply(`Healed '${characterName}' by ${amount}. New HP: ${newHP}`);
+          message.reply(
+            `Healed '${characterName}' by ${amount}. New HP: ${newHP}`,
+          );
         } catch (err) {
           message.reply(`Error applying healing: ${err.message}`);
         }
       }
-      
+
       case COMMANDS.WOUND: {
         if (args.length < 2) {
           message.reply(USAGE.WOUND);
@@ -351,12 +367,17 @@ function startBot() {
         try {
           const newWounds = wound(characterName, amount);
           if (newWounds == -1) {
-            message.reply(`'${characterName}' is already at max wounds (6), cannot be wounded further.`);
-          }
-          else {
-            message.reply(`Inflicted ${amount} wounds to '${characterName}'. New wound count: ${newWounds}`);
+            message.reply(
+              `'${characterName}' is already at max wounds (6), cannot be wounded further.`,
+            );
+          } else {
+            message.reply(
+              `Inflicted ${amount} wounds to '${characterName}'. New wound count: ${newWounds}`,
+            );
             if (newWounds >= 6) {
-              message.reply(`'${characterName}' has suffered 6 wounds and is now dead.`);
+              message.reply(
+                `'${characterName}' has suffered 6 wounds and is now dead.`,
+              );
             }
           }
         } catch (err) {
@@ -370,23 +391,25 @@ function startBot() {
           return;
         }
         const characterName = args[0];
-        const { initiative } = require('./commands/initiative');
+        const { initiative } = require("./commands/initiative");
         try {
           const result = initiative(characterName);
           let reply = `Initiative for '${characterName}':\nRoll: ${result.initiativeRoll.rolls}\nTotal Initiative: ${result.initiativeRoll.total}
             \n${result.actions} action(s) to start with.`;
-          if (result.isCritSuccess) reply += `\n${require('./constants/dice').CRIT_SUCCESS_MSG}`;
-          if (result.isCritFailure) reply += `\n${require('./constants/dice').CRIT_FAILURE_MSG}`;
-          
+          if (result.isCritSuccess)
+            reply += `\n${require("./constants/dice").CRIT_SUCCESS_MSG}`;
+          if (result.isCritFailure)
+            reply += `\n${require("./constants/dice").CRIT_FAILURE_MSG}`;
+
           message.reply(reply);
-        } catch (err)  {
+        } catch (err) {
           message.reply(`Error rolling initiative: ${err.message}`);
         }
         break;
       }
 
       case COMMANDS.ALLSPELLS: {
-        const allspellsModule = require('./commands/allspells');
+        const allspellsModule = require("./commands/allspells");
         try {
           await allspellsModule.execute(message, args);
         } catch (err) {
@@ -404,7 +427,6 @@ function startBot() {
         // Optionally handle unknown commands
         break;
     }
-
   });
 
   client.login(process.env.DISCORD_TOKEN);

--- a/src/commands/searchSpell.js
+++ b/src/commands/searchSpell.js
@@ -1,0 +1,49 @@
+// searchSpell.js
+// Command to search for a spell by name in spellbook.json and return its description
+
+const fs = require('fs');
+const path = require('path');
+
+const SPELLBOOK_PATH = path.join(__dirname, '../../rule_documents/text_documents/spellbook.json');
+
+module.exports = {
+  name: 'searchspell',
+  description: 'Search for a spell by name and return its description.',
+  execute: async (message, args) => {
+    if (!args.length) {
+      return message.reply('Please provide the name of the spell to search for.');
+    }
+    const spellName = args.join(' ').toLowerCase();
+    let spellbook;
+    try {
+      spellbook = JSON.parse(fs.readFileSync(SPELLBOOK_PATH, 'utf8'));
+    } catch (err) {
+      return message.reply('Could not load the spellbook.');
+    }
+    let foundSpell = null;
+    for (const school in spellbook.spells) {
+      for (const spell of spellbook.spells[school]) {
+        if (spell.name.toLowerCase() === spellName) {
+          foundSpell = spell;
+          break;
+        }
+      }
+      if (foundSpell) break;
+    }
+    if (!foundSpell) {
+      return message.reply(`Spell "${args.join(' ')}" not found in the spellbook.`);
+    }
+    let response = `**${foundSpell.name}**\n`;
+    if (foundSpell.tier) response += `*Tier:* ${foundSpell.tier}\n`;
+    if (foundSpell.cost) response += `*Cost:* ${foundSpell.cost}\n`;
+    if (foundSpell.type) response += `*Type:* ${foundSpell.type}\n`;
+    if (foundSpell.range) response += `*Range:* ${foundSpell.range}\n`;
+    if (foundSpell.damage) response += `*Damage:* ${foundSpell.damage}\n`;
+    if (foundSpell.effect) response += `*Effect:* ${foundSpell.effect}\n`;
+    if (foundSpell.high_levels) response += `*High Levels:* ${foundSpell.high_levels}\n`;
+    if (foundSpell.upcast) response += `*Upcast:* ${foundSpell.upcast}\n`;
+    if (foundSpell.duration) response += `*Duration:* ${foundSpell.duration}\n`;
+    response += `*Description:* ${foundSpell.description}`;
+    return message.reply(response);
+  }
+};

--- a/src/constants/commands.js
+++ b/src/constants/commands.js
@@ -17,7 +17,8 @@ const COMMANDS = {
   UPSKILL: "Usage: !upskill <characterName> <skillName>",
   INITIATIVE: '!initiative',
   CONDITION: '!condition',
-  ALLSPELLS: '!allspells'
+  ALLSPELLS: '!allspells',
+  SEARCH_SPELL: '!searchspell'
 };
 
 const USAGE = {
@@ -35,6 +36,7 @@ const USAGE = {
   CONDITION: 'Usage: !condition <characterName> <condition_name>\nDescription: Toggle a condition for a character.',
   ALLSPELLS: 'Usage: !allspells',
   DAMAGE: 'Usage: !damage <characterName> <amount>',
+  SEARCH_SPELL: 'Usage: !searchspell <spell name>',
   HEAL: 'Usage: !heal <characterName> <amount>',
   WOUND: 'Usage: !wound <characterName> <amount>',
   INITIATIVE: 'Usage: !initiative <characterName>'


### PR DESCRIPTION
Players can now search for the rule of a chosen spell through the json dictionary. Nothing complicated here, just added the new command in bot.js and created an execution file. All constants have been updated accordingly.

closes #40 